### PR TITLE
Support for AARCH64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           echo "OPENCV_VERSION_SHORT=$(mvn build-helper:parse-version org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=opencv.version.short -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Build OpenCV on Arm
-        uses: uraimo/run-on-arch-action@v2.0.9
+        uses: uraimo/run-on-arch-action@v2
         with:
           arch: armv7
           distro: ubuntu18.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           echo "OPENCV_VERSION_SHORT=$(mvn build-helper:parse-version org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=opencv.version.short -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Build OpenCV on Arm
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v2.0.10
         with:
           arch: armv7
           distro: ubuntu18.04
@@ -145,7 +145,7 @@ jobs:
           echo "OPENCV_VERSION_SHORT=$(mvn build-helper:parse-version org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=opencv.version.short -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Build OpenCV on Arm64
-        uses: uraimo/run-on-arch-action@v2.0.9
+        uses: uraimo/run-on-arch-action@v2.0.10
         with:
           arch: aarch64
           distro: ubuntu18.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,7 @@ jobs:
           cp opencv-${{ env.OPENCV_VERSION }}/build/bin/opencv-${{ env.OPENCV_VERSION_SHORT }}.jar upstream || :
           cp opencv-${{ env.OPENCV_VERSION }}/build/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/x86_64 || :
           cp opencv-${{ env.OPENCV_VERSION }}/build/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/x86_64 || :
+          cp opencv-${{ env.OPENCV_VERSION }}/build/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/ARMv8 || :
 
       - name: Build with Maven
         run: mvn -B test
@@ -365,6 +366,7 @@ jobs:
         run: |
           cp macos-10.15/bin/opencv-${{ env.OPENCV_VERSION_SHORT }}.jar upstream
           cp macos-10.15/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/x86_64
+          cp macos-10.15/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/ARMv8
           cp ubuntu-18.04/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/x86_64
           cp ubuntu-18.04-arm/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv7
           cp ubuntu-18.04-arm64/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv8
@@ -457,6 +459,7 @@ jobs:
         run: |
           cp macos-10.15/bin/opencv-${{ env.OPENCV_VERSION_SHORT }}.jar upstream
           cp macos-10.15/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/x86_64
+          cp macos-10.15/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/ARMv8
           cp ubuntu-18.04/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/x86_64
           cp ubuntu-18.04-arm/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv7
           cp ubuntu-18.04-arm64/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,7 +391,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15, windows-2016, windows-2019, ubuntu-20.04, ubuntu-18.04]
-        java: [8, 9, 10, 11, 12, 13, 14, 15]
+        java: [8, 11]
 
     runs-on: ${{ matrix.os }}
 
@@ -467,12 +467,9 @@ jobs:
           cp windows-2016/x64/opencv_java${{ env.OPENCV_VERSION_SHORT }}.dll src/main/resources/nu/pattern/opencv/windows/x86_64
 
       - name: Publish to Apache Maven Central
+        if: github.repository == 'openpnp/opencv' && github.repository == 'openpnp/openpnp-capture' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         run: mvn -B -e clean deploy -P release-sign-artifacts
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,6 @@
           </excludes>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -270,10 +269,7 @@
           </execution>
         </executions>
         <configuration>
-          <links>
-            <link>http://docs.opencv.org/java/</link>
-            <link>http://docs.oracle.com/javase/8/docs/api/</link>
-          </links>
+          <doclint>none</doclint>
           <additionalparam>${javadoc.parameters}</additionalparam>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>bundle</packaging>
   <groupId>org.openpnp</groupId>
   <artifactId>opencv</artifactId>
-  <version>4.5.1-2</version>
+  <version>4.5.2</version>
   <name>OpenPnP OpenCV</name>
   <description>OpenCV packaged with native libraries and loader for multiple platforms.</description>
   <url>http://github.com/openpnp/opencv</url>

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -177,7 +177,7 @@ public class OpenCV {
   }
 
   /**
-   * Exactly once per {@link ClassLoader}, attempt to load the native library (via {@link System#loadLibrary(String)} with {@link Core#NATIVE_LIBRARY_NAME}). If the first attempt fails, the native binary will be extracted from the classpath to a temporary location (which gets cleaned up on shutdown), that location is added to the {@code java.library.path} system property and {@link ClassLoader#usr_paths}, and then another call to load the library is made. Note this method uses reflection to gain access to private memory in {@link ClassLoader} as there's no documented method to augment the library path at runtime. Spurious calls are safe.
+   * Exactly once per {@link ClassLoader}, attempt to load the native library (via {@link System#loadLibrary(String)} with {@link Core#NATIVE_LIBRARY_NAME}). If the first attempt fails, the native binary will be extracted from the classpath to a temporary location (which gets cleaned up on shutdown), that location is added to the {@code java.library.path} system property and {@link ClassLoader}, and then another call to load the library is made. Note this method uses reflection to gain access to private memory in {@link ClassLoader} as there's no documented method to augment the library path at runtime. Spurious calls are safe.
    */
   public static void loadShared() {
     SharedLoader.getInstance();
@@ -266,7 +266,7 @@ public class OpenCV {
     }
 
     /**
-     * Adds the provided {@link Path}, normalized, to the {@link ClassLoader#usr_paths} array, as well as to the {@code java.library.path} system property. Uses the reflection API to make the field accessible, and may be unsafe in environments with a security policy.
+     * Adds the provided {@link Path}, normalized, to the {@link ClassLoader} array, as well as to the {@code java.library.path} system property. Uses the reflection API to make the field accessible, and may be unsafe in environments with a security policy.
      *
      * @see <a href="http://stackoverflow.com/q/15409223">Adding new paths for native libraries at runtime in Java</a>
      */
@@ -293,7 +293,7 @@ public class OpenCV {
     }
 
     /**
-     * Removes the provided {@link Path}, normalized, from the {@link ClassLoader#usr_paths} array, as well as to the {@code java.library.path} system property. Uses the reflection API to make the field accessible, and may be unsafe in environments with a security policy.
+     * Removes the provided {@link Path}, normalized, from the {@link ClassLoader} array, as well as to the {@code java.library.path} system property. Uses the reflection API to make the field accessible, and may be unsafe in environments with a security policy.
      */
     private static void removeLibraryPath(final Path path) {
       final String normalizedPath = path.normalize().toString();

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -65,7 +65,7 @@ public class OpenCV {
   }
 
   static enum Arch {
-    X86_32("i386", "i686", "x86"),
+    X86_32("i386", "i686", "x86", "x86_32"),
     X86_64("amd64", "x86_64"),
     ARMv7("arm"),
     ARMv8("aarch64", "arm64");

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -360,13 +360,13 @@ public class OpenCV {
       case LINUX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java451.so";
+            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java452.so";
             break;
           case ARMv7:
-            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java451.so";
+            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java452.so";
             break;
           case ARMv8:
-            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java451.so";
+            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java452.so";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -375,13 +375,13 @@ public class OpenCV {
       case OSX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java451.dylib";
+            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java452.dylib";
             break;
 //          case AARCH64:
-//            location = "/nu/pattern/opencv/osx/AARCH64/libopencv_java451.dylib";
+//            location = "/nu/pattern/opencv/osx/AARCH64/libopencv_java452.dylib";
 //            break;
           case ARMv8:
-            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java451.dylib";
+            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java452.dylib";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -390,10 +390,10 @@ public class OpenCV {
       case WINDOWS:
           switch (arch) {
             case X86_32:
-              location = "/nu/pattern/opencv/windows/x86_32/opencv_java451.dll";
+              location = "/nu/pattern/opencv/windows/x86_32/opencv_java452.dll";
               break;
             case X86_64:
-              location = "/nu/pattern/opencv/windows/x86_64/opencv_java451.dll";
+              location = "/nu/pattern/opencv/windows/x86_64/opencv_java452.dll";
               break;
             default:
               throw new UnsupportedPlatformException(os, arch);

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -377,8 +377,11 @@ public class OpenCV {
           case X86_64:
             location = "/nu/pattern/opencv/osx/x86_64/libopencv_java451.dylib";
             break;
-	  case AARCH64:
-            location = "/nu/pattern/opencv/osx/AARCH64/libopencv_java451.dylib";
+//          case AARCH64:
+//            location = "/nu/pattern/opencv/osx/AARCH64/libopencv_java451.dylib";
+//            break;
+          case ARMv8:
+            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java451.dylib";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -377,6 +377,9 @@ public class OpenCV {
           case X86_64:
             location = "/nu/pattern/opencv/osx/x86_64/libopencv_java451.dylib";
             break;
+	  case AARCH64:
+            location = "/nu/pattern/opencv/osx/AARCH64/libopencv_java451.dylib";
+            break;
           default:
             throw new UnsupportedPlatformException(os, arch);
         }


### PR DESCRIPTION
Otherwise `mvn package` on an Apple M1 goes:

```
[ERROR] Tests run: 3, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 0.133 s <<< FAILURE! - in EagleMountsmdUlpImporterTest
[ERROR] testWholeNumbers  Time elapsed: 0.109 s  <<< ERROR!
java.lang.Exception: Error while reading machine.xml (null)
	at EagleMountsmdUlpImporterTest.testWholeNumbers(EagleMountsmdUlpImporterTest.java:64)
Caused by: java.lang.reflect.InvocationTargetException
	at EagleMountsmdUlpImporterTest.testWholeNumbers(EagleMountsmdUlpImporterTest.java:64)
Caused by: java.lang.ExceptionInInitializerError
	at EagleMountsmdUlpImporterTest.testWholeNumbers(EagleMountsmdUlpImporterTest.java:64)
Caused by: nu.pattern.OpenCV$UnsupportedPlatformException: Operating system "OSX" and architecture "ARMv8" are not supported.
	at EagleMountsmdUlpImporterTest.testWholeNumbers(EagleMountsmdUlpImporterTest.java:64)
```