### PR TITLE
Bump opencv to 4.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,10 +404,10 @@ jobs:
           echo "OPENCV_VERSION_SHORT=$(mvn build-helper:parse-version org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=opencv.version.short -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Download Windows Distribution
-        run: wget -O opencv-${{ env.OPENCV_VERSION }}-vc14_vc15.exe https://sourceforge.net/projects/opencvlibrary/files/${{ env.OPENCV_VERSION }}/opencv-${{ env.OPENCV_VERSION }}-vc14_vc15.exe/download
+        run: wget -O opencv-${{ env.OPENCV_VERSION }}.exe https://github.com/opencv/opencv/releases/download/${{ env.OPENCV_VERSION }}/opencv-${{ env.OPENCV_VERSION }}-windows.exe
 
       - name: Extract Windows Distribution
-        run: 7z x opencv-${{ env.OPENCV_VERSION }}-vc14_vc15.exe
+        run: 7z x opencv-${{ env.OPENCV_VERSION }}.exe
           
       - name: Upload Libraries
         uses: actions/upload-artifact@v2

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>bundle</packaging>
   <groupId>org.openpnp</groupId>
   <artifactId>opencv</artifactId>
-  <version>4.6.0-0</version>
+  <version>4.7.0-0</version>
   <name>OpenPnP OpenCV</name>
   <description>OpenCV packaged with native libraries and loader for multiple platforms.</description>
   <url>http://github.com/openpnp/opencv</url>

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -360,13 +360,13 @@ public class OpenCV {
       case LINUX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java460.so";
+            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java470.so";
             break;
           case ARMv7:
-            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java460.so";
+            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java470.so";
             break;
           case ARMv8:
-            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java460.so";
+            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java470.so";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -375,10 +375,10 @@ public class OpenCV {
       case OSX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java460.dylib";
+            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java470.dylib";
             break;
           case ARMv8:
-            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java460.dylib";
+            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java470.dylib";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -387,10 +387,10 @@ public class OpenCV {
       case WINDOWS:
           switch (arch) {
             case X86_32:
-              location = "/nu/pattern/opencv/windows/x86_32/opencv_java460.dll";
+              location = "/nu/pattern/opencv/windows/x86_32/opencv_java470.dll";
               break;
             case X86_64:
-              location = "/nu/pattern/opencv/windows/x86_64/opencv_java460.dll";
+              location = "/nu/pattern/opencv/windows/x86_64/opencv_java470.dll";
               break;
             default:
               throw new UnsupportedPlatformException(os, arch);


### PR DESCRIPTION
This PR bumps opencv version to 4.7.0.

I have run the checks, including the macos arm64, and it seems OK to me.
<img width="1429" alt="Screenshot 2023-03-20 at 11 39 21" src="https://user-images.githubusercontent.com/648603/226248412-c004c689-281b-4ce9-96db-d36e5e04a9e7.png">
