### PR TITLE
Bump opencv to 4.8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   build_linux_arm: 
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
         java: [8]
 
     runs-on: ${{ matrix.os }}
@@ -127,7 +127,7 @@ jobs:
   build_linux_arm64: 
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
         java: [15]
 
     runs-on: ${{ matrix.os }}
@@ -235,7 +235,7 @@ jobs:
   build_mac_linux_x64:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         java: [8]
 
     runs-on: ${{ matrix.os }}
@@ -383,7 +383,7 @@ jobs:
   build_windows:
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         java: [15]
 
     runs-on: ${{ matrix.os }}
@@ -425,7 +425,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         java: [8]
 
     runs-on: ${{ matrix.os }}
@@ -450,10 +450,10 @@ jobs:
 
       - name: Copy Binaries
         run: |
-          cp macos-10.15/bin/opencv-${{ env.OPENCV_VERSION_SHORT }}.jar upstream
-          cp macos-10.15/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/x86_64
+          cp macos-11/bin/opencv-${{ env.OPENCV_VERSION_SHORT }}.jar upstream
+          cp macos-11/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/x86_64
           cp macos-aarch64/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/ARMv8
-          cp ubuntu-18.04/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/x86_64
+          cp ubuntu-20.04/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/x86_64
           cp ubuntu-18.04-arm/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv7
           cp ubuntu-18.04-arm64/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv8
           cp windows-2016/x86/opencv_java${{ env.OPENCV_VERSION_SHORT }}.dll src/main/resources/nu/pattern/opencv/windows/x86_32
@@ -479,7 +479,7 @@ jobs:
     needs: build_dist
     strategy:
       matrix:
-        os: [macos-10.15, windows-2019, ubuntu-20.04, ubuntu-18.04]
+        os: [macos-11, windows-2019, ubuntu-20.04, ubuntu-22.04]
         java: [8, 9, 10, 11, 12, 13, 14, 15]
 
     runs-on: ${{ matrix.os }}
@@ -519,7 +519,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         java: [8]
 
     runs-on: ${{ matrix.os }}
@@ -549,10 +549,10 @@ jobs:
 
       - name: Copy Binaries
         run: |
-          cp macos-10.15/bin/opencv-${{ env.OPENCV_VERSION_SHORT }}.jar upstream
-          cp macos-10.15/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/x86_64
+          cp macos-11/bin/opencv-${{ env.OPENCV_VERSION_SHORT }}.jar upstream
+          cp macos-11/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/x86_64
           cp macos-aarch64/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.dylib src/main/resources/nu/pattern/opencv/osx/ARMv8
-          cp ubuntu-18.04/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/x86_64
+          cp ubuntu-20.04/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/x86_64
           cp ubuntu-18.04-arm/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv7
           cp ubuntu-18.04-arm64/lib/libopencv_java${{ env.OPENCV_VERSION_SHORT }}.so src/main/resources/nu/pattern/opencv/linux/ARMv8
           cp windows-2016/x86/opencv_java${{ env.OPENCV_VERSION_SHORT }}.dll src/main/resources/nu/pattern/opencv/windows/x86_32

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>bundle</packaging>
   <groupId>org.openpnp</groupId>
   <artifactId>opencv</artifactId>
-  <version>4.7.0-0</version>
+  <version>4.8.1-0</version>
   <name>OpenPnP OpenCV</name>
   <description>OpenCV packaged with native libraries and loader for multiple platforms.</description>
   <url>http://github.com/openpnp/opencv</url>

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -360,13 +360,13 @@ public class OpenCV {
       case LINUX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java470.so";
+            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java481.so";
             break;
           case ARMv7:
-            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java470.so";
+            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java481.so";
             break;
           case ARMv8:
-            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java470.so";
+            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java481.so";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -375,10 +375,10 @@ public class OpenCV {
       case OSX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java470.dylib";
+            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java481.dylib";
             break;
           case ARMv8:
-            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java470.dylib";
+            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java481.dylib";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -387,10 +387,10 @@ public class OpenCV {
       case WINDOWS:
           switch (arch) {
             case X86_32:
-              location = "/nu/pattern/opencv/windows/x86_32/opencv_java470.dll";
+              location = "/nu/pattern/opencv/windows/x86_32/opencv_java481.dll";
               break;
             case X86_64:
-              location = "/nu/pattern/opencv/windows/x86_64/opencv_java470.dll";
+              location = "/nu/pattern/opencv/windows/x86_64/opencv_java481.dll";
               break;
             default:
               throw new UnsupportedPlatformException(os, arch);


### PR DESCRIPTION
* Bump opencv to 4.8.1
* Change ubuntu-18.04 runner to ubuntu 20.04 and ubuntu-22.04 due to [depreciation](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/). ARM distros are still ubuntu 18.
* Change macos-10.15 runner to macos-11 due to [depreciation](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/)
* Closes https://github.com/openpnp/opencv/issues/102
* Closes https://github.com/openpnp/opencv/issues/97