### PR TITLE
Update OpenCV paths and version to 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>bundle</packaging>
   <groupId>org.openpnp</groupId>
   <artifactId>opencv</artifactId>
-  <version>4.8.1-0</version>
+  <version>4.9.0-0</version>
   <name>OpenPnP OpenCV</name>
   <description>OpenCV packaged with native libraries and loader for multiple platforms.</description>
   <url>http://github.com/openpnp/opencv</url>

--- a/src/main/java/nu/pattern/OpenCV.java
+++ b/src/main/java/nu/pattern/OpenCV.java
@@ -360,13 +360,13 @@ public class OpenCV {
       case LINUX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java481.so";
+            location = "/nu/pattern/opencv/linux/x86_64/libopencv_java490.so";
             break;
           case ARMv7:
-            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java481.so";
+            location = "/nu/pattern/opencv/linux/ARMv7/libopencv_java490.so";
             break;
           case ARMv8:
-            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java481.so";
+            location = "/nu/pattern/opencv/linux/ARMv8/libopencv_java490.so";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -375,10 +375,10 @@ public class OpenCV {
       case OSX:
         switch (arch) {
           case X86_64:
-            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java481.dylib";
+            location = "/nu/pattern/opencv/osx/x86_64/libopencv_java490.dylib";
             break;
           case ARMv8:
-            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java481.dylib";
+            location = "/nu/pattern/opencv/osx/ARMv8/libopencv_java490.dylib";
             break;
           default:
             throw new UnsupportedPlatformException(os, arch);
@@ -387,10 +387,10 @@ public class OpenCV {
       case WINDOWS:
           switch (arch) {
             case X86_32:
-              location = "/nu/pattern/opencv/windows/x86_32/opencv_java481.dll";
+              location = "/nu/pattern/opencv/windows/x86_32/opencv_java490.dll";
               break;
             case X86_64:
-              location = "/nu/pattern/opencv/windows/x86_64/opencv_java481.dll";
+              location = "/nu/pattern/opencv/windows/x86_64/opencv_java490.dll";
               break;
             default:
               throw new UnsupportedPlatformException(os, arch);


### PR DESCRIPTION
The OpenCV locations have been updated for LINUX, OSX, and WINDOWS platforms across different architectures (x86_64, ARMv7, and ARMv8) to reflect the new version 4.9.0. Similarly, the version in pom.xml has been changed from 4.8.1-0 to 4.9.0-0.